### PR TITLE
Update to (d17d6e7f1 2015-04-02) (built 2015-04-03)

### DIFF
--- a/src/estimate.rs
+++ b/src/estimate.rs
@@ -1,5 +1,4 @@
 use tables;
-use std::num::Float;
 
 /// Returns estimated bounds for π(*n*), the number of primes less
 /// than or equal to `n`.
@@ -118,8 +117,6 @@ pub fn estimate_nth_prime(n: u64) -> (u64, u64) {
 
 #[cfg(test)]
 mod tests {
-    use std::num::Int;
-
     use Primes;
     use super::{estimate_prime_pi, estimate_nth_prime};
 

--- a/src/fast_sieve.rs
+++ b/src/fast_sieve.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{BitVec};
 use std::{cmp};
-use std::num::Float;
 
 use Primes;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! let (_lo, hi) = slow_primes::estimate_nth_prime(10001);
 //!
 //! // find the primes up to this upper bound
-//! let sieve = slow_primes::Primes::sieve(hi as uint);
+//! let sieve = slow_primes::Primes::sieve(hi as usize);
 //!
 //! // (.nth is zero indexed.)
 //! match sieve.primes().nth(10001 - 1) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,10 @@
 //! git = "https://github.com/huonw/slow_primes"
 //! ```
 
-#![feature(collections, core)]
+#![feature(collections)]
 #![cfg_attr(test, feature(test, step_by))]
 
-extern crate "num" as num_;
+extern crate num as num_;
 
 #[cfg(test)] extern crate test;
 

--- a/src/perfect_power.rs
+++ b/src/perfect_power.rs
@@ -1,8 +1,7 @@
 use num_::Integer;
-use std::num::{Float, Int};
 
 fn wrapping_pow(mut base: u64, mut exp: u32) -> u64 {
-    let mut acc = 1;
+    let mut acc: u64 = 1;
     while exp > 0 {
         if exp % 2 == 1 {
             acc = acc.wrapping_mul(base)

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -1,6 +1,5 @@
 use std::collections::{BitVec, bit_vec};
 use std::{iter, cmp};
-use std::num::Float;
 
 use Factors;
 
@@ -200,7 +199,6 @@ impl<'a> DoubleEndedIterator for PrimeIterator<'a> {
 mod tests {
     use test::Bencher;
     use super::Primes;
-    use std::num::Int;
 
     #[test]
     fn is_prime() {
@@ -243,12 +241,10 @@ mod tests {
         let primes = Primes::sieve(50);
         let mut expected = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47];
 
-        assert_eq!(primes.primes().collect::<Vec<usize>>().as_slice(),
-                   expected.as_slice());
+        assert_eq!(primes.primes().collect::<Vec<usize>>(), expected);
 
         expected.reverse();
-        assert_eq!(primes.primes().rev().collect::<Vec<usize>>().as_slice(),
-                   expected.as_slice());
+        assert_eq!(primes.primes().rev().collect::<Vec<usize>>(), expected);
     }
 
     #[test]
@@ -316,7 +312,7 @@ mod tests {
                 };
 
                 // break into the two parts
-                let (low, hi) = real.as_slice().split_at(last_short_prime);
+                let (low, hi) = real.split_at(last_short_prime);
                 let leftover = hi.iter().fold(1, |x, &(p, i)| x * p.pow(i as u32));
 
                 assert_eq!(possible, Err((leftover, low.to_vec())));


### PR DESCRIPTION
Fixed extern crate import and removed deprecated traits. These changes are compatible with the latest nightly but _not_ the 1.0.0 beta (`BitVec` is still unstable, unfortunately).
